### PR TITLE
Add convenience methods for point-based interval queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ let hasConflict = tree.hasOverlap(with: 4...6) // true
 let containing = tree.containing(4)
 // Returns: [(1...5, "Task A"), (3...8, "Task B")]
 
+// Check if any interval contains a point (efficient existence check)
+let hasPoint = tree.contains(4) // true
+
+// Find intervals that start at a specific point
+let startingAt = tree.starting(at: 1)
+// Returns: [(1...5, "Task A")]
+
+// Find intervals that end at a specific point
+let endingAt = tree.ending(at: 8)
+// Returns: [(3...8, "Task B")]
+
+// Get just the values for intervals containing a point
+let values = tree.values(containing: 4)
+// Returns: ["Task A", "Task B"]
+
+// Use subscript syntax for point queries
+let pointValues = tree[4] // ["Task A", "Task B"]
+
 // Find intervals completely contained within a range
 let contained = tree.contained(in: 0...10)
 // Returns: [(1...5, "Task A"), (3...8, "Task B")]
@@ -84,6 +102,9 @@ for (interval, value) in tree {
 
 // Use subscript to get overlapping values
 let values = tree[4...6] // ["Task A", "Task B"]
+
+// Use subscript to get values for intervals containing a point
+let pointValues = tree[4] // ["Task A", "Task B"]
 
 // Access by index
 let first = tree[tree.startIndex] // (1...5, "Task A")

--- a/Tests/IntervalTreeTests/IntervalTreeTests.swift
+++ b/Tests/IntervalTreeTests/IntervalTreeTests.swift
@@ -115,6 +115,77 @@ func testPointContainment() {
     #expect(containing50.isEmpty)
 }
 
+@Test("Point-based convenience methods")
+func testPointBasedConvenienceMethods() {
+    var tree = IntervalTree<Int, String>()
+
+    tree.insert(10...20, value: "A")
+    tree.insert(15...25, value: "B")
+    tree.insert(30...40, value: "C")
+    tree.insert(10...30, value: "D")
+    tree.insert(5...15, value: "E")
+
+    // Test contains(_ point:) method
+    #expect(tree.contains(15))
+    #expect(tree.contains(35))
+    #expect(tree.contains(5))  // Point 5 is contained in interval 5...15
+    #expect(!tree.contains(50))
+
+    // Test starting(at:) method
+    let startingAt10 = tree.starting(at: 10)
+    #expect(startingAt10.count == 2)
+    #expect(startingAt10.contains { $0.1 == "A" })
+    #expect(startingAt10.contains { $0.1 == "D" })
+
+    let startingAt15 = tree.starting(at: 15)
+    #expect(startingAt15.count == 1)
+    #expect(startingAt15.first?.1 == "B")
+
+    let startingAt5 = tree.starting(at: 5)
+    #expect(startingAt5.count == 1)
+    #expect(startingAt5.first?.1 == "E")
+
+    // Test ending(at:) method
+    let endingAt20 = tree.ending(at: 20)
+    #expect(endingAt20.count == 1)
+    #expect(endingAt20.first?.1 == "A")
+
+    let endingAt25 = tree.ending(at: 25)
+    #expect(endingAt25.count == 1)
+    #expect(endingAt25.first?.1 == "B")
+
+    let endingAt30 = tree.ending(at: 30)
+    #expect(endingAt30.count == 1)
+    #expect(endingAt30.first?.1 == "D")
+
+    // Test values(containing:) method
+    let valuesContaining15 = tree.values(containing: 15)
+    #expect(valuesContaining15.count == 4)
+    #expect(valuesContaining15.contains("A"))
+    #expect(valuesContaining15.contains("B"))
+    #expect(valuesContaining15.contains("D"))
+    #expect(valuesContaining15.contains("E"))
+
+    let valuesContaining35 = tree.values(containing: 35)
+    #expect(valuesContaining35.count == 1)
+    #expect(valuesContaining35.contains("C"))
+
+    // Test subscript access for points
+    let subscriptValues15 = tree[15]
+    #expect(subscriptValues15.count == 4)
+    #expect(subscriptValues15.contains("A"))
+    #expect(subscriptValues15.contains("B"))
+    #expect(subscriptValues15.contains("D"))
+    #expect(subscriptValues15.contains("E"))
+
+    let subscriptValues35 = tree[35]
+    #expect(subscriptValues35.count == 1)
+    #expect(subscriptValues35.contains("C"))
+
+    let subscriptValues50 = tree[50]
+    #expect(subscriptValues50.isEmpty)
+}
+
 // MARK: - Collection Protocol Tests
 
 @Test("Collection protocol compliance")


### PR DESCRIPTION
This PR adds several convenience methods for point-based queries:

- `contains(_ point: Bound) -> Bool`
- `starting(at point: Bound) -> [(ClosedRange<Bound>, Value)]`
- `ending(at point: Bound) -> [(ClosedRange<Bound>, Value)]`
- `values(containing point: Bound) -> [Value]`
- `subscript(point: Bound) -> [Value]`

```swift
let tree = IntervalTree([(1...5, "A"), (3...8, "B"), (10...15, "C")])

tree.contains(4)                    // true
tree.starting(at: 1)               // [(1...5, "A")]
tree.ending(at: 8)                 // [(3...8, "B")]
tree.values(containing: 4)         // ["A", "B"]
tree[4]                           // ["A", "B"]
```

Previously, these operations required API callers to construct and pass a closed range (e.g. `value...value`), which was clunky. 

All of these changes are additive, and have no impact on existing usage.